### PR TITLE
Clarify canonical import path, fix broken links.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - go get golang.org/x/tools/cmd/vet
 
 script:
+  - export TZ=US/Pacific # TODO: Fix this.
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d ./)
   - go tool vet ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,19 @@
 language: go
 
-go: 1.4
+go:
+  - 1.4
+
+before_install:
+  - mkdir -p $HOME/gopath/src/sourcegraph.com/sourcegraph
+  - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/sourcegraph.com/sourcegraph/go-diff
+  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/sourcegraph.com/sourcegraph/go-diff
+  - cd $TRAVIS_BUILD_DIR
+
+install:
+  - go get golang.org/x/tools/cmd/vet
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d ./)
+  - go tool vet ./
+  - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 
-go: 1.3
+go: 1.4

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-# go-diff [![status](https://sourcegraph.com/api/repos/github.com/sourcegraph/go-diff/.badges/status.png)](https://sourcegraph.com/github.com/sourcegraph/go-diff) [![views](https://sourcegraph.com/api/repos/github.com/sourcegraph/go-diff/.counters/views.png)](https://sourcegraph.com/github.com/sourcegraph/go-diff)
+# go-diff [![Build Status](https://travis-ci.org/sourcegraph/go-diff.svg?branch=master)](https://travis-ci.org/sourcegraph/go-diff) [![status](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-diff/.badges/status.png)](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff) [![views](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-diff/.counters/views.png)](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff)
 
 Diff parser and printer for Go.
 
 **Unstable API:** go-diff is currently in development. If you depend on it, you should vendor it.
 
-It doesn't actually compute a diff. It only reads in (and prints out,
-given a Go struct representation) unified diff output, such as the
-following. The corresponding data structure in Go is the
-[diff.FileDiff](https://sourcegraph.com/github.com/sourcegraph/go-diff/.GoPackage/github.com/sourcegraph/go-diff/diff/.def/FileDiff)
-struct.
+Installing
+----------
+
+```bash
+go get -u sourcegraph.com/sourcegraph/go-diff/diff
+```
+
+Usage
+-----
+
+It doesn't actually compute a diff. It only reads in (and prints out, given a Go struct representation) unified diff output, such as the following. The corresponding data structure in Go is the [`diff.FileDiff`](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff/.GoPackage/sourcegraph.com/sourcegraph/go-diff/diff/.def/FileDiff) struct.
 
 ```diff
 --- oldname	2009-10-11 15:12:20.000000000 -0700

--- a/diff/doc.go
+++ b/diff/doc.go
@@ -1,2 +1,2 @@
 // Package diff provides a parser for unified diffs.
-package diff
+package diff // import "sourcegraph.com/sourcegraph/go-diff/diff"


### PR DESCRIPTION
- The canonical import path for this package appears to be `sourcegraph.com/sourcegraph/go-diff/diff`, not `github.com/sourcegraph/go-diff/diff`. Add an import path comment to enforce and document this. Also mention the import path in README, so there's no need to guess what it actually is.
- Fix broken views counter image.
    - [![views](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-diff/.counters/views.png)](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff)
- Fix broken definition link.
    - [`diff.FileDiff`](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff/.GoPackage/sourcegraph.com/sourcegraph/go-diff/diff/.def/FileDiff)
- Add Travis build status badge.
    - [![Build Status](https://travis-ci.org/sourcegraph/go-diff.svg?branch=master)](https://travis-ci.org/sourcegraph/go-diff)
- Update Travis Go to current version.
- Fix Travis build so it passes.