### PR TITLE
Update Travis to use Go 1.6.2; fix broken links/images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
+sudo: false
 language: go
-
 go:
-  - 1.4
-
+  - 1.6.2
+  - tip
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 before_install:
   - mkdir -p $HOME/gopath/src/sourcegraph.com/sourcegraph
   - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/sourcegraph.com/sourcegraph/go-diff
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/sourcegraph.com/sourcegraph/go-diff
   - cd $TRAVIS_BUILD_DIR
-
 install:
-  - go get golang.org/x/tools/cmd/vet
-
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
   - go get -t -v ./...
-  - diff -u <(echo -n) <(gofmt -d ./)
-  - go tool vet ./
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
   - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-diff [![Build Status](https://travis-ci.org/sourcegraph/go-diff.svg?branch=master)](https://travis-ci.org/sourcegraph/go-diff) [![status](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-diff/.badges/status.png)](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff) [![views](https://sourcegraph.com/api/repos/sourcegraph.com/sourcegraph/go-diff/.counters/views.png)](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff)
+# go-diff [![Build Status](https://travis-ci.org/sourcegraph/go-diff.svg?branch=master)](https://travis-ci.org/sourcegraph/go-diff) [![GoDoc](https://godoc.org/github.com/sourcegraph/go-diff?status.svg)](https://godoc.org/github.com/sourcegraph/go-diff)
 
 Diff parser and printer for Go.
 
@@ -14,7 +14,7 @@ go get -u sourcegraph.com/sourcegraph/go-diff/diff
 Usage
 -----
 
-It doesn't actually compute a diff. It only reads in (and prints out, given a Go struct representation) unified diff output, such as the following. The corresponding data structure in Go is the [`diff.FileDiff`](https://sourcegraph.com/sourcegraph.com/sourcegraph/go-diff/.GoPackage/sourcegraph.com/sourcegraph/go-diff/diff/.def/FileDiff) struct.
+It doesn't actually compute a diff. It only reads in (and prints out, given a Go struct representation) unified diff output, such as the following. The corresponding data structure in Go is the [`diff.FileDiff`](https://sourcegraph.com/github.com/sourcegraph/go-diff/-/def/GoPackage/github.com/sourcegraph/go-diff/diff/-/FileDiff) struct.
 
 ```diff
 --- oldname	2009-10-11 15:12:20.000000000 -0700


### PR DESCRIPTION
sourcegraph.com doesn't support status and views badges anymore, so remove those since they're broken images.

Update a link to a [`diff.FileDiff`](https://sourcegraph.com/github.com/sourcegraph/go-diff/-/def/GoPackage/github.com/sourcegraph/go-diff/diff/-/FileDiff) def using current sourcegraph.com URL pattern.

This PR fixes Travis CI so that new builds succeed. That will allow PR #13 to have passing status after this is merged and it's rebased on top.