### PR TITLE
diff: fix time format

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -62,7 +62,7 @@ const hunkHeader = "@@ -%d,%d +%d,%d @@"
 // diffTimeFormat is the time format string for unified diff file
 // header timestamps. See
 // http://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html.
-const diffTimeFormat = "2006-01-02 15:04:05.000000000 -0700"
+const diffTimeFormat = "2006-01-02 15:04:05.999999999 -0700"
 
 func (s *Stat) add(o Stat) {
 	s.Added += o.Added


### PR DESCRIPTION
It seems that the fractional seconds part is optional, so change the format to accept whole seconds too.

Here's a sample diff output by the bzr command which fails to parse currently.

I started adding a test, but it involves more time than I have to spend right now, as the tests rely on reflect.DeepEqual working on time.Time instances, which won't work in general due to monotonic time. I'd suggest using https://godoc.org/github.com/google/go-cmp/cmp#Diff instead.

	=== modified file 'encode.go'
	--- encode.go	2011-11-24 19:47:20 +0000
	+++ encode.go	2011-11-28 13:24:31 +0000
	@@ -250,8 +250,7 @@
	 	e.emitScalar("null", "", "", C.YAML_PLAIN_SCALAR_STYLE)
	 }

	-func (e *encoder) emitScalar(value, anchor, tag string,
	-	style C.yaml_scalar_style_t) {
	+func (e *encoder) emitScalar(value, anchor, tag string, style C.yaml_scalar_style_t) {
	 	var canchor, ctag, cvalue *C.yaml_char_t
	 	var cimplicit C.int
	 	var free func()

	=== modified file 'encode_test.go'
	--- encode_test.go	2011-11-24 19:47:20 +0000
	+++ encode_test.go	2011-11-28 13:24:39 +0000
	@@ -76,6 +76,10 @@
	 		A int "a,omitempty"
	 		B int "b,omitempty"
	 	}{0, 0}},
	+	{"{}\n", &struct {
	+		A *struct{ X int } "a,omitempty"
	+		B int              "b,omitempty"
	+	}{nil, 0}},

	 	// Flow flag
	 	{"a: [1, 2]\n", &struct {

	=== modified file 'goyaml.go'
	--- goyaml.go	2011-11-24 19:47:20 +0000
	+++ goyaml.go	2011-11-28 13:24:39 +0000
	@@ -256,7 +256,7 @@
	 	switch v.Kind() {
	 	case reflect.String:
	 		return len(v.String()) == 0
	-	case reflect.Interface:
	+	case reflect.Interface, reflect.Ptr:
	 		return v.IsNil()
	 	case reflect.Slice:
	 		return v.Len() == 0