### PR TITLE
Add support for parsing header timestamps without fractional seconds.

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -59,10 +59,15 @@ var (
 
 const hunkHeader = "@@ -%d,%d +%d,%d @@"
 
-// diffTimeFormat is the time format string for unified diff file
-// header timestamps. See
-// http://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html.
-const diffTimeFormat = "2006-01-02 15:04:05.000000000 -0700"
+// diffTimeParseLayout is the layout used to parse the time in unified diff file
+// header timestamps.
+// See https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html.
+const diffTimeParseLayout = "2006-01-02 15:04:05 -0700"
+
+// diffTimeFormatLayout is the layout used to format (i.e., print) the time in unified diff file
+// header timestamps.
+// See https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html.
+const diffTimeFormatLayout = "2006-01-02 15:04:05.000000000 -0700"
 
 func (s *Stat) add(o Stat) {
 	s.Added += o.Added

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -109,6 +109,15 @@ func TestParseFileDiffHeaders(t *testing.T) {
 			},
 		},
 		{
+			filename: "sample_file_no_fractional_seconds.diff",
+			wantDiff: &FileDiff{
+				OrigName: "goyaml.go",
+				OrigTime: &pbtypes.Timestamp{Seconds: 1322164040},
+				NewName:  "goyaml.go",
+				NewTime:  &pbtypes.Timestamp{Seconds: 1322486679},
+			},
+		},
+		{
 			filename: "sample_file_extended.diff",
 			wantDiff: &FileDiff{
 				OrigName: "oldname",

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -267,7 +267,7 @@ func (r *FileDiffReader) readOneFileHeader(prefix []byte) (filename string, time
 	filename = parts[0]
 	if len(parts) == 2 {
 		// Timestamp is optional, but this header has it.
-		ts, err := time.Parse(diffTimeFormat, parts[1])
+		ts, err := time.Parse(diffTimeParseLayout, parts[1])
 		if err != nil {
 			return "", nil, err
 		}

--- a/diff/print.go
+++ b/diff/print.go
@@ -71,7 +71,7 @@ func printFileHeader(w io.Writer, prefix string, filename string, timestamp *tim
 		return err
 	}
 	if timestamp != nil {
-		if _, err := fmt.Fprint(w, "\t", timestamp.Format(diffTimeFormat)); err != nil {
+		if _, err := fmt.Fprint(w, "\t", timestamp.Format(diffTimeFormatLayout)); err != nil {
 			return err
 		}
 	}

--- a/diff/testdata/sample_file_no_fractional_seconds.diff
+++ b/diff/testdata/sample_file_no_fractional_seconds.diff
@@ -1,0 +1,11 @@
+--- goyaml.go	2011-11-24 19:47:20 +0000
++++ goyaml.go	2011-11-28 13:24:39 +0000
+@@ -256,7 +256,7 @@
+ 	switch v.Kind() {
+ 	case reflect.String:
+ 		return len(v.String()) == 0
+-	case reflect.Interface:
++	case reflect.Interface, reflect.Ptr:
+ 		return v.IsNil()
+ 	case reflect.Slice:
+ 		return v.Len() == 0


### PR DESCRIPTION
We need to use a different layout string for parsing and printing, since we only want to change the parsing behavior (not printing behavior).

Add test for it. Without the change to parsing layout, the test fails with:

```
$ go test
--- FAIL: TestParseFileDiffHeaders (0.00s)
	diff_test.go:214: sample_file_no_fractional_seconds.diff: got ParseFileDiff error parsing time "2011-11-24 19:47:20 +0000" as "2006-01-02 15:04:05.000000000 -0700": cannot parse " +0000" as ".000000000"
FAIL
FAIL	sourcegraph.com/sourcegraph/go-diff/diff	0.010s
```

Resolves #17. /cc @rogpeppe