### PR TITLE
add 1.10.x travis build for verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: go
 go:
-  - 1.x
-  - tip
+  - "1.10.x"
+  - "1.x"
+  - "tip"
 matrix:
   allow_failures:
     - go: tip


### PR DESCRIPTION
it could be good to run a build with the previous version of Go (`1.10.x`) to make sure it still builds and works with the "old" pre-module way.