### PR TITLE
Update documentation for ParseMultiFileDiff

### DIFF
--- a/diff/parse.go
+++ b/diff/parse.go
@@ -12,9 +12,10 @@ import (
 	"sourcegraph.com/sqs/pbtypes"
 )
 
-// ParseMultiFileDiff parses a multi-file unified diff. It returns an error if parsing failed as a whole, but does its
-// best to parse as many files in the case of per-file errors. In the case of non-fatal per-file errors, the error
-// return value is null and the Errs field in the returned MultiFileDiff is set.
+// ParseMultiFileDiff parses a multi-file unified diff. It returns an error if
+// parsing failed as a whole, but does its best to parse as many files in the
+// case of per-file errors. If it cannot detect when the diff of the next file
+// begins, the hunks are added to the FileDiff of the previous file.
 func ParseMultiFileDiff(diff []byte) ([]*FileDiff, error) {
 	return NewMultiFileDiffReader(bytes.NewReader(diff)).ReadAllFiles()
 }


### PR DESCRIPTION
I ran into this when trying to parse a "multi file diff" that I generated by concatenating multiple file diffs without putting a `diff [...] a/<filename> b/<filename>` between each single file diff. Reproduction here: https://play.golang.org/p/pxPb6sJfyor

This updates the documentation to describe the behavior and also remove outdated information about error handling.