### PR TITLE
diff: support renamed, updated binary file

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -216,6 +216,23 @@ func TestParseFileDiffHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			filename: "sample_file_extended_binary_rename.diff",
+			wantDiff: &FileDiff{
+				OrigName: "a/data/Font.png",
+				OrigTime: nil,
+				NewName:  "b/data/Other.png",
+				NewTime:  nil,
+				Extended: []string{
+					"diff --git a/data/Font.png b/data/Other.png",
+					"similarity index 51%",
+					"rename from data/Font.png",
+					"rename to data/Other.png",
+					"index 17a971d..599f8dd 100644",
+					"Binary files a/data/Font.png and b/data/Other.png differ",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -397,6 +397,11 @@ func handleEmpty(fd *FileDiff) (wasEmpty bool) {
 			fd.NewName = names[1]
 		}
 		return true
+	case lineCount == 6 && strings.HasPrefix(fd.Extended[5], "Binary files ") && strings.HasPrefix(fd.Extended[2], "rename from ") && strings.HasPrefix(fd.Extended[3], "rename to "):
+		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
+		fd.OrigName = names[0]
+		fd.NewName = names[1]
+		return true
 	case lineCount == 3 && strings.HasPrefix(fd.Extended[2], "Binary files ") || lineCount > 3 && strings.HasPrefix(fd.Extended[2], "GIT binary patch"):
 		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
 		fd.OrigName, err = strconv.Unquote(names[0])

--- a/diff/testdata/sample_file_extended_binary_rename.diff
+++ b/diff/testdata/sample_file_extended_binary_rename.diff
@@ -1,0 +1,6 @@
+diff --git a/data/Font.png b/data/Other.png
+similarity index 51%
+rename from data/Font.png
+rename to data/Other.png
+index 17a971d..599f8dd 100644
+Binary files a/data/Font.png and b/data/Other.png differ


### PR DESCRIPTION
This commit parses a diff with a renamed, updated binary file and adds a test case for it.