### PR TITLE
Add handling added/deleted files in diff

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -54,10 +54,12 @@ func (h *Hunk) Stat() Stat {
 }
 
 var (
-	hunkPrefix = []byte("@@ ")
+	hunkPrefix          = []byte("@@ ")
+	onlyInMessagePrefix = []byte("Only in ")
 )
 
 const hunkHeader = "@@ -%d,%d +%d,%d @@"
+const onlyInMessage = "Only in %s: %s\n"
 
 // diffTimeParseLayout is the layout used to parse the time in unified diff file
 // header timestamps.

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -572,13 +572,44 @@ func TestParseMultiFileDiffHeaders(t *testing.T) {
 					},
 				},
 				{
+					OrigName: "source_b/file_3.txt some unrelated stuff here.",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+				{
 					OrigName: "source_b/file_3.txt",
 					OrigTime: nil,
 					NewName:  "",
 					NewTime:  nil,
-					Extended: []string{
-						"Only in source_b: file_3.txt some unrelated stuff here.",
-					},
+					Extended: nil,
+				},
+			},
+		},
+		{
+			filename: "sample_onlyin_complex_filenames.diff",
+			wantDiffs: []*FileDiff{
+				{
+					OrigName: "internal/trace/foo bar/bam",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+				{
+					OrigName: "internal/trace/foo bar/bam: bar",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+				{
+					OrigName: "internal/trace/hello/world: bazz",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
 				},
 			},
 		},
@@ -662,7 +693,8 @@ func TestParseMultiFileDiffAndPrintMultiFileDiff(t *testing.T) {
 		{filename: "empty_multi.diff", wantFileDiffs: 2},
 		{filename: "sample_contains_added_deleted_files.diff", wantFileDiffs: 3},
 		{filename: "sample_contains_only_added_deleted_files.diff", wantFileDiffs: 3},
-		{filename: "sample_onlyin_line_isnt_a_file_header.diff", wantFileDiffs: 3},
+		{filename: "sample_onlyin_line_isnt_a_file_header.diff", wantFileDiffs: 4},
+		{filename: "sample_onlyin_complex_filenames.diff", wantFileDiffs: 3},
 	}
 	for _, test := range tests {
 		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -496,6 +496,60 @@ func TestParseMultiFileDiffHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			filename: "sample_contains_added_deleted_files.diff",
+			wantDiffs: []*FileDiff{
+				{
+					OrigName: "source_a/file_1.txt",
+					OrigTime: nil,
+					NewName:  "source_b/file_1.txt",
+					NewTime:  nil,
+					Extended: []string{
+						"diff -u source_a/file_1.txt  source_b/file_1.txt",
+					},
+				},
+				{
+					OrigName: "source_a/file_2.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+				{
+					OrigName: "source_b/file_3.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+			},
+		},
+		{
+			filename: "sample_contains_only_added_deleted_files.diff",
+			wantDiffs: []*FileDiff{
+				{
+					OrigName: "source_a/file_1.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+				{
+					OrigName: "source_a/file_2.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+				{
+					OrigName: "source_b/file_3.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: nil,
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
@@ -574,6 +628,8 @@ func TestParseMultiFileDiffAndPrintMultiFileDiff(t *testing.T) {
 		{filename: "long_line_multi.diff", wantFileDiffs: 3},
 		{filename: "empty.diff", wantFileDiffs: 0},
 		{filename: "empty_multi.diff", wantFileDiffs: 2},
+		{filename: "sample_contains_added_deleted_files.diff", wantFileDiffs: 3},
+		{filename: "sample_contains_only_added_deleted_files.diff", wantFileDiffs: 3},
 	}
 	for _, test := range tests {
 		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -550,6 +550,38 @@ func TestParseMultiFileDiffHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			filename: "sample_onlyin_line_isnt_a_file_header.diff",
+			wantDiffs: []*FileDiff{
+				{
+					OrigName: "source_a/file_1.txt",
+					OrigTime: nil,
+					NewName:  "source_b/file_1.txt",
+					NewTime:  nil,
+					Extended: []string{
+						"diff -u source_a/file_1.txt  source_b/file_1.txt",
+					},
+				},
+				{
+					OrigName: "source_a/file_2.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: []string{
+						"Only in universe!",
+					},
+				},
+				{
+					OrigName: "source_b/file_3.txt",
+					OrigTime: nil,
+					NewName:  "",
+					NewTime:  nil,
+					Extended: []string{
+						"Only in source_b: file_3.txt some unrelated stuff here.",
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
@@ -630,6 +662,7 @@ func TestParseMultiFileDiffAndPrintMultiFileDiff(t *testing.T) {
 		{filename: "empty_multi.diff", wantFileDiffs: 2},
 		{filename: "sample_contains_added_deleted_files.diff", wantFileDiffs: 3},
 		{filename: "sample_contains_only_added_deleted_files.diff", wantFileDiffs: 3},
+		{filename: "sample_onlyin_line_isnt_a_file_header.diff", wantFileDiffs: 3},
 	}
 	for _, test := range tests {
 		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))

--- a/diff/print.go
+++ b/diff/print.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"path/filepath"
 	"time"
 
 	"sourcegraph.com/sqs/pbtypes"
@@ -34,6 +35,16 @@ func PrintFileDiff(d *FileDiff) ([]byte, error) {
 		if _, err := fmt.Fprintln(&buf, xheader); err != nil {
 			return nil, err
 		}
+	}
+
+	// FileDiff is added/deleted file
+	// No further hunks printing needed
+	if d.NewName == "" {
+		_, err := fmt.Fprintf(&buf, onlyInMessage, filepath.Dir(d.OrigName), filepath.Base(d.OrigName))
+		if err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
 	}
 
 	if d.Hunks == nil {

--- a/diff/testdata/sample_contains_added_deleted_files.diff
+++ b/diff/testdata/sample_contains_added_deleted_files.diff
@@ -1,0 +1,11 @@
+diff -u source_a/file_1.txt  source_b/file_1.txt
+--- source_a/file_1.txt
++++ source_b/file_1.txt
+@@ -2,3 +3,4 @@
+ To be, or not to be, that is the question:
+-Whether 'tis nobler in the mind to suffer
++The slings and arrows of outrageous fortune,
++Or to take arms against a sea of troubles
+ And by opposing end them. To die—to sleep,
+Only in source_a: file_2.txt
+Only in source_b: file_3.txt

--- a/diff/testdata/sample_contains_only_added_deleted_files.diff
+++ b/diff/testdata/sample_contains_only_added_deleted_files.diff
@@ -1,0 +1,3 @@
+Only in source_a: file_1.txt
+Only in source_a: file_2.txt
+Only in source_b: file_3.txt

--- a/diff/testdata/sample_onlyin_complex_filenames.diff
+++ b/diff/testdata/sample_onlyin_complex_filenames.diff
@@ -1,0 +1,3 @@
+Only in internal/trace/foo bar: bam
+Only in internal/trace/foo bar: bam: bar
+Only in internal/trace/hello: world: bazz

--- a/diff/testdata/sample_onlyin_line_isnt_a_file_header.diff
+++ b/diff/testdata/sample_onlyin_line_isnt_a_file_header.diff
@@ -1,0 +1,13 @@
+diff -u source_a/file_1.txt  source_b/file_1.txt
+--- source_a/file_1.txt
++++ source_b/file_1.txt
+@@ -2,3 +3,4 @@
+ To be, or not to be, that is the question:
+-Whether 'tis nobler in the mind to suffer
++The slings and arrows of outrageous fortune,
++Or to take arms against a sea of troubles
+ And by opposing end them. To die—to sleep,
+Only in universe!
+Only in source_a: file_2.txt
+Only in source_b: file_3.txt some unrelated stuff here.
+Only in source_b: file_3.txt


### PR DESCRIPTION
Related issue: https://github.com/sourcegraph/go-diff/issues/49
closes #49 


There are some changes from planned implementation:
- empty NewName marked as empty string instead of `nil`
- files aren't determined if they are from original source or new one. All filenames from such messages will be added to `OrigName` field.
 `[2].OrigName: "source_b/file_3.txt` and `[2].NewName: ""` will be relevant.
Because in case diff file only contains messages about added/deleted files, it is impossible to determine which of the sources is the original one.


Then for this file example, the output below for ReadAllFiles() would be expected.
my_diff.txt
```diff
diff -u source_a/file_1.txt  source_b/file_1.txt
--- source_a/file_1.txt   2020-07-28 12:54:18.000000000 +0000
+++ source_b/file_1.txt  2020-07-28 12:54:18.000000000 +0000
@@ -2,3 +3,4 @@
 To be, or not to be, that is the question:
-Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles
 And by opposing end them. To die—to sleep,
Only in source_a: file_2.txt
Only in source_b: file_3.txt
```
```
ReadAllFiles(myMultiFileDiffReader) -> {
    FileDiff{
        OrigName: “source_a/file_1.txt”, 
        OrigTime: ..., 
        NewName: “source_b/file_1.txt”, 
        NewTime: …,
        Entended: ..., 
        Hunks: …
    },
 
    FileDiff{
        OrigName: “source_a/file_2.txt”, 
        OrigTime: nil, 
        NewName: "", 
        NewTime: nil
        …
    }, 

    FileDiff{
        OrigName: “source_b/file_3.txt”, 
        OrigTime: nil, 
        NewName: "", 
        …
    }

}, nil
```