### PR TITLE
Handle rename-and-mode-change in empty file diffs & clean up code

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -151,6 +151,20 @@ func TestParseFileDiffHeaders(t *testing.T) {
 			},
 		},
 		{
+			filename: "sample_file_extended_empty_mode_change.diff",
+			wantDiff: &FileDiff{
+				OrigName: "a/docs/index.md",
+				OrigTime: nil,
+				NewName:  "b/docs/index.md",
+				NewTime:  nil,
+				Extended: []string{
+					"diff --git a/docs/index.md b/docs/index.md",
+					"old mode 100644",
+					"new mode 100755",
+				},
+			},
+		},
+		{
 			filename: "sample_file_extended_empty_new_binary.diff",
 			wantDiff: &FileDiff{
 				OrigName: "/dev/null",
@@ -210,6 +224,23 @@ func TestParseFileDiffHeaders(t *testing.T) {
 			},
 		},
 		{
+			filename: "sample_file_extended_empty_rename_and_mode_change.diff",
+			wantDiff: &FileDiff{
+				OrigName: "a/textfile.txt",
+				OrigTime: nil,
+				NewName:  "b/textfile2.txt",
+				NewTime:  nil,
+				Extended: []string{
+					"diff --git a/textfile.txt b/textfile2.txt",
+					"old mode 100644",
+					"new mode 100755",
+					"similarity index 100%",
+					"rename from textfile.txt",
+					"rename to textfile2.txt",
+				},
+			},
+		},
+		{
 			filename: "quoted_filename.diff",
 			wantDiff: &FileDiff{
 				OrigName: "a/商品详情.txt",
@@ -241,19 +272,21 @@ func TestParseFileDiffHeaders(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
-		if err != nil {
-			t.Fatal(err)
-		}
-		diff, err := ParseFileDiff(diffData)
-		if err != nil {
-			t.Fatalf("%s: got ParseFileDiff error %v", test.filename, err)
-		}
+		t.Run(test.filename, func(t *testing.T) {
+			diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			diff, err := ParseFileDiff(diffData)
+			if err != nil {
+				t.Fatalf("%s: got ParseFileDiff error %v", test.filename, err)
+			}
 
-		diff.Hunks = nil
-		if got, want := diff, test.wantDiff; !cmp.Equal(got, want) {
-			t.Errorf("%s:\n\ngot - want:\n%s", test.filename, cmp.Diff(want, got))
-		}
+			diff.Hunks = nil
+			if got, want := diff, test.wantDiff; !cmp.Equal(got, want) {
+				t.Errorf("%s:\n\ngot - want:\n%s", test.filename, cmp.Diff(want, got))
+			}
+		})
 	}
 }
 
@@ -672,21 +705,23 @@ func TestParseMultiFileDiffHeaders(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
-		if err != nil {
-			t.Fatal(err)
-		}
-		diffs, err := ParseMultiFileDiff(diffData)
-		if err != nil {
-			t.Fatalf("%s: got ParseMultiFileDiff error %v", test.filename, err)
-		}
+		t.Run(test.filename, func(t *testing.T) {
+			diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			diffs, err := ParseMultiFileDiff(diffData)
+			if err != nil {
+				t.Fatalf("%s: got ParseMultiFileDiff error %v", test.filename, err)
+			}
 
-		for i := range diffs {
-			diffs[i].Hunks = nil // This test focuses on things other than hunks, so don't compare them.
-		}
-		if got, want := diffs, test.wantDiffs; !cmp.Equal(got, want) {
-			t.Errorf("%s:\n\ngot - want:\n%s", test.filename, cmp.Diff(want, got))
-		}
+			for i := range diffs {
+				diffs[i].Hunks = nil // This test focuses on things other than hunks, so don't compare them.
+			}
+			if got, want := diffs, test.wantDiffs; !cmp.Equal(got, want) {
+				t.Errorf("%s:\n\ngot - want:\n%s", test.filename, cmp.Diff(want, got))
+			}
+		})
 	}
 }
 

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -357,92 +357,58 @@ func (r *FileDiffReader) ReadExtendedHeaders() ([]string, error) {
 // handleEmpty detects when FileDiff was an empty diff and will not have any hunks
 // that follow. It updates fd fields from the parsed extended headers.
 func handleEmpty(fd *FileDiff) (wasEmpty bool) {
-	var err error
 	lineCount := len(fd.Extended)
 	if lineCount > 0 && !strings.HasPrefix(fd.Extended[0], "diff --git ") {
 		return false
 	}
-	switch {
-	case (lineCount == 3 || lineCount == 4 && strings.HasPrefix(fd.Extended[3], "Binary files ") || lineCount > 4 && strings.HasPrefix(fd.Extended[3], "GIT binary patch")) &&
-		strings.HasPrefix(fd.Extended[1], "old mode ") && strings.HasPrefix(fd.Extended[2], "new mode "):
 
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName, err = strconv.Unquote(names[0])
-		if err != nil {
-			fd.OrigName = names[0]
-		}
-		fd.NewName, err = strconv.Unquote(names[1])
-		if err != nil {
-			fd.NewName = names[1]
-		}
-		return true
-	case (lineCount == 3 || lineCount == 4 && strings.HasPrefix(fd.Extended[3], "Binary files ") || lineCount > 4 && strings.HasPrefix(fd.Extended[3], "GIT binary patch")) &&
-		strings.HasPrefix(fd.Extended[1], "new file mode "):
+	lineHasPrefix := func(idx int, prefix string) bool {
+		return strings.HasPrefix(fd.Extended[idx], prefix)
+	}
 
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName = "/dev/null"
-		fd.NewName, err = strconv.Unquote(names[1])
-		if err != nil {
-			fd.NewName = names[1]
-		}
-		return true
-	case (lineCount == 3 || lineCount == 4 && strings.HasPrefix(fd.Extended[3], "Binary files ") || lineCount > 4 && strings.HasPrefix(fd.Extended[3], "GIT binary patch")) &&
-		strings.HasPrefix(fd.Extended[1], "deleted file mode "):
+	linesHavePrefixes := func(idx1 int, prefix1 string, idx2 int, prefix2 string) bool {
+		return lineHasPrefix(idx1, prefix1) && lineHasPrefix(idx2, prefix2)
+	}
 
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName, err = strconv.Unquote(names[0])
-		if err != nil {
-			fd.OrigName = names[0]
-		}
-		fd.NewName = "/dev/null"
-		return true
-	case lineCount == 4 && strings.HasPrefix(fd.Extended[2], "rename from ") && strings.HasPrefix(fd.Extended[3], "rename to "):
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName, err = strconv.Unquote(names[0])
-		if err != nil {
-			fd.OrigName = names[0]
-		}
-		fd.NewName, err = strconv.Unquote(names[1])
-		if err != nil {
-			fd.NewName = names[1]
-		}
-		return true
-	case lineCount == 6 && strings.HasPrefix(fd.Extended[2], "rename from ") && strings.HasPrefix(fd.Extended[3], "rename to ") && strings.HasPrefix(fd.Extended[5], "Binary files "):
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName, err = strconv.Unquote(names[0])
-		if err != nil {
-			fd.OrigName = names[0]
-		}
-		fd.NewName, err = strconv.Unquote(names[1])
-		if err != nil {
-			fd.NewName = names[1]
-		}
-		return true
-	case lineCount == 6 && strings.HasPrefix(fd.Extended[4], "rename from ") && strings.HasPrefix(fd.Extended[5], "rename to "):
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName, err = strconv.Unquote(names[0])
-		if err != nil {
-			fd.OrigName = names[0]
-		}
-		fd.NewName, err = strconv.Unquote(names[1])
-		if err != nil {
-			fd.NewName = names[1]
-		}
-		return true
-	case lineCount == 3 && strings.HasPrefix(fd.Extended[2], "Binary files ") || lineCount > 3 && strings.HasPrefix(fd.Extended[2], "GIT binary patch"):
-		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName, err = strconv.Unquote(names[0])
-		if err != nil {
-			fd.OrigName = names[0]
-		}
-		fd.NewName, err = strconv.Unquote(names[1])
-		if err != nil {
-			fd.NewName = names[1]
-		}
-		return true
-	default:
+	isRename := (lineCount == 4 && linesHavePrefixes(2, "rename from ", 3, "rename to ")) ||
+		(lineCount == 6 && linesHavePrefixes(2, "rename from ", 3, "rename to ") && lineHasPrefix(5, "Binary files ")) ||
+		(lineCount == 6 && linesHavePrefixes(1, "old mode ", 2, "new mode ") && linesHavePrefixes(4, "rename from ", 5, "rename to "))
+
+	isDeletedFile := (lineCount == 3 || lineCount == 4 && lineHasPrefix(3, "Binary files ") || lineCount > 4 && lineHasPrefix(3, "GIT binary patch")) &&
+		lineHasPrefix(1, "deleted file mode ")
+
+	isNewFile := (lineCount == 3 || lineCount == 4 && lineHasPrefix(3, "Binary files ") || lineCount > 4 && lineHasPrefix(3, "GIT binary patch")) &&
+		lineHasPrefix(1, "new file mode ")
+
+	isModeChange := lineCount == 3 && linesHavePrefixes(1, "old mode ", 2, "new mode ")
+
+	isBinaryPatch := lineCount == 3 && lineHasPrefix(2, "Binary files ") || lineCount > 3 && lineHasPrefix(2, "GIT binary patch")
+
+	if !isModeChange && !isRename && !isBinaryPatch && !isNewFile && !isDeletedFile {
 		return false
 	}
+
+	names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
+
+	var err error
+	fd.OrigName, err = strconv.Unquote(names[0])
+	if err != nil {
+		fd.OrigName = names[0]
+	}
+	fd.NewName, err = strconv.Unquote(names[1])
+	if err != nil {
+		fd.NewName = names[1]
+	}
+
+	if isNewFile {
+		fd.OrigName = "/dev/null"
+	}
+
+	if isDeletedFile {
+		fd.NewName = "/dev/null"
+	}
+
+	return true
 }
 
 var (

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -407,10 +407,27 @@ func handleEmpty(fd *FileDiff) (wasEmpty bool) {
 			fd.NewName = names[1]
 		}
 		return true
-	case lineCount == 6 && strings.HasPrefix(fd.Extended[5], "Binary files ") && strings.HasPrefix(fd.Extended[2], "rename from ") && strings.HasPrefix(fd.Extended[3], "rename to "):
+	case lineCount == 6 && strings.HasPrefix(fd.Extended[2], "rename from ") && strings.HasPrefix(fd.Extended[3], "rename to ") && strings.HasPrefix(fd.Extended[5], "Binary files "):
 		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
-		fd.OrigName = names[0]
-		fd.NewName = names[1]
+		fd.OrigName, err = strconv.Unquote(names[0])
+		if err != nil {
+			fd.OrigName = names[0]
+		}
+		fd.NewName, err = strconv.Unquote(names[1])
+		if err != nil {
+			fd.NewName = names[1]
+		}
+		return true
+	case lineCount == 6 && strings.HasPrefix(fd.Extended[4], "rename from ") && strings.HasPrefix(fd.Extended[5], "rename to "):
+		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)
+		fd.OrigName, err = strconv.Unquote(names[0])
+		if err != nil {
+			fd.OrigName = names[0]
+		}
+		fd.NewName, err = strconv.Unquote(names[1])
+		if err != nil {
+			fd.NewName = names[1]
+		}
 		return true
 	case lineCount == 3 && strings.HasPrefix(fd.Extended[2], "Binary files ") || lineCount > 3 && strings.HasPrefix(fd.Extended[2], "GIT binary patch"):
 		names := strings.SplitN(fd.Extended[0][len("diff --git "):], " ", 2)

--- a/diff/testdata/sample_file_extended_empty_mode_change.diff
+++ b/diff/testdata/sample_file_extended_empty_mode_change.diff
@@ -1,0 +1,3 @@
+diff --git a/docs/index.md b/docs/index.md
+old mode 100644
+new mode 100755

--- a/diff/testdata/sample_file_extended_empty_rename_and_mode_change.diff
+++ b/diff/testdata/sample_file_extended_empty_rename_and_mode_change.diff
@@ -1,0 +1,6 @@
+diff --git a/textfile.txt b/textfile2.txt
+old mode 100644
+new mode 100755
+similarity index 100%
+rename from textfile.txt
+rename to textfile2.txt


### PR DESCRIPTION
This is a bit of a follow-up to https://github.com/sourcegraph/go-diff/pull/57 in that it adds another test for file mode changes, in which a file's mode has changed _and_ it has been renamed. I also duplicated the test added in #57 for single file diffs, so these tests are next to each other.

Besides that I used `t.Run` in the the two test functions I was working with to make it easier to see which test is failing and I tried to clean up the parsing code as best as I could. Tests helped a lot here.