### PR TITLE
MultiFileDiffReader returns trailing content

### DIFF
--- a/diff/testdata/sample_multi_file_trailing_content.diff
+++ b/diff/testdata/sample_multi_file_trailing_content.diff
@@ -1,0 +1,24 @@
+some leading content
+diff --git a/comment-last-line.sql b/comment-last-line.sql
+index 04a1655..97bd115 100644
+--- a/comment-last-line.sql
++++ b/comment-last-line.sql
+@@ -1,4 +1,4 @@
+ select 1;
++++ invalid SQL comment
+ select 2;
+ select 3;
+--- end of three queries
+some content between diffs
+diff --git a/query.sql b/query.sql
+index 9537d7b..234ef35 100644
+--- a/query.sql
++++ b/query.sql
+@@ -1,5 +1,4 @@
+ select 1;
+--- this is my query
+ select 2;
+ select 3;
+--- this is the last line
++++ invalid sql comment
+some trailing content

--- a/diff/testdata/sample_multi_file_trailing_content_diffsonly.diff
+++ b/diff/testdata/sample_multi_file_trailing_content_diffsonly.diff
@@ -1,0 +1,23 @@
+some leading content
+diff --git a/comment-last-line.sql b/comment-last-line.sql
+index 04a1655..97bd115 100644
+--- a/comment-last-line.sql
++++ b/comment-last-line.sql
+@@ -1,4 +1,4 @@
+ select 1;
++++ invalid SQL comment
+ select 2;
+ select 3;
+--- end of three queries
+some content between diffs
+diff --git a/query.sql b/query.sql
+index 9537d7b..234ef35 100644
+--- a/query.sql
++++ b/query.sql
+@@ -1,5 +1,4 @@
+ select 1;
+--- this is my query
+ select 2;
+ select 3;
+--- this is the last line
++++ invalid sql comment


### PR DESCRIPTION
Along with EOF. This is useful for handling mixed diff and non-diff
output. Note that "stray" content between diff files was already
included in the extended headers for the next diff. All this commit does
is return a partial FileDiff, with only extended headers and no actual
diff content, along with an EOF.

---

Fixes https://github.com/sourcegraph/go-diff/issues/59