### PR TITLE
Support renamed binary files without index-row

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -271,6 +271,22 @@ func TestParseFileDiffHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			filename: "sample_file_extended_binary_rename_no_index.diff",
+			wantDiff: &FileDiff{
+				OrigName: "a/data/foo.txt",
+				OrigTime: nil,
+				NewName:  "b/data/bar.txt",
+				NewTime:  nil,
+				Extended: []string{
+					"diff --git a/data/foo.txt b/data/bar.txt",
+					"similarity index 100%",
+					"rename from data/foo.txt",
+					"rename to data/bar.txt",
+					"Binary files a/data/foo.txt and b/data/bar.txt differ",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.filename, func(t *testing.T) {

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -489,6 +489,7 @@ func handleEmpty(fd *FileDiff) (wasEmpty bool) {
 		(lineCount == 6 && linesHavePrefixes(1, "old mode ", 2, "new mode ") && linesHavePrefixes(4, "copy from ", 5, "copy to "))
 
 	isRename := (lineCount == 4 && linesHavePrefixes(2, "rename from ", 3, "rename to ")) ||
+		(lineCount == 5 && linesHavePrefixes(2, "rename from ", 3, "rename to ") && lineHasPrefix(4, "Binary files ")) ||
 		(lineCount == 6 && linesHavePrefixes(2, "rename from ", 3, "rename to ") && lineHasPrefix(5, "Binary files ")) ||
 		(lineCount == 6 && linesHavePrefixes(1, "old mode ", 2, "new mode ") && linesHavePrefixes(4, "rename from ", 5, "rename to "))
 

--- a/diff/testdata/sample_file_extended_binary_rename_no_index.diff
+++ b/diff/testdata/sample_file_extended_binary_rename_no_index.diff
@@ -1,0 +1,5 @@
+diff --git a/data/foo.txt b/data/bar.txt
+similarity index 100%
+rename from data/foo.txt
+rename to data/bar.txt
+Binary files a/data/foo.txt and b/data/bar.txt differ


### PR DESCRIPTION
I found a wild diff generated by libgit2 that was previously unparsable by go-diff. The only difference in this diff (included as testdata) and diffs that are parsable by go-diff is the "index" row, such as "index 17a971d..599f8dd 100644".

This commit adds support for renamed binary files without that index row.