### PR TITLE
Fix parsing of deleted empty files without a/ b/ prefixes

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -783,6 +783,56 @@ func TestParseMultiFileDiffHeaders(t *testing.T) {
 				},
 			},
 		},
+		{
+			filename: "delete_empty_file.diff",
+			wantDiffs: []*FileDiff{
+				{
+					OrigName: "Euler 0011/README.txt~",
+					NewName:  "/dev/null",
+					Extended: []string{
+						"diff --git Euler 0011/README.txt~ Euler 0011/README.txt~",
+						"deleted file mode 100644",
+						"index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000",
+					},
+				},
+				{
+					OrigName: "Euler 0011/Euler0011.cpp",
+					NewName:  "/dev/null",
+					Extended: []string{
+						"diff --git Euler 0011/Euler0011.cpp Euler 0011/Euler0011.cpp",
+						"deleted file mode 100644",
+						"index 6490416c8cb4bbf2afbafa66251a9eab983086d1..0000000000000000000000000000000000000000",
+					},
+				},
+				{
+					OrigName: "Euler 0011/README.txt~",
+					NewName:  "/dev/null",
+					Extended: []string{
+						"diff --git Euler 0011/README.txt~ Euler 0011/README.txt~",
+						"deleted file mode 100644",
+						"index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000",
+					},
+				},
+				{
+					OrigName: "Euler 0011/README.txt",
+					NewName:  "/dev/null",
+					Extended: []string{
+						"diff --git Euler 0011/README.txt Euler 0011/README.txt",
+						"deleted file mode 100644",
+						"index f8ea904baa27c54eb73cc02d5a555878b28672ff..0000000000000000000000000000000000000000",
+					},
+				},
+				{
+					OrigName: "Euler 0011/README.txt~",
+					NewName:  "/dev/null",
+					Extended: []string{
+						"diff --git Euler 0011/README.txt~ Euler 0011/README.txt~",
+						"deleted file mode 100644",
+						"index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000",
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.filename, func(t *testing.T) {

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -436,8 +436,17 @@ func parseDiffGitArgs(diffArgs string) (string, string, bool) {
 		// to handle that case here.
 		first := diffArgs[:length/2]
 		second := diffArgs[length/2+1:]
-		if len(first) >= 3 && length%2 == 1 && first[1] == '/' && first[1:] == second[1:] {
-			return first, second, true
+
+		// If the two strings could be equal, based on length, proceed.
+		if length%2 == 1 {
+			// If the name minus the a/ b/ prefixes is equal, proceed.
+			if len(first) >= 3 && length%2 == 1 && first[1] == '/' && first[1:] == second[1:] {
+				return first, second, true
+			}
+			// If the names don't have the a/ and b/ prefixes and they're equal, proceed.
+			if !(first[:2] == "a/" && second[:2] == "b/") && first == second {
+				return first, second, true
+			}
 		}
 
 		// The syntax is (unfortunately) valid, but we could not extract

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -440,7 +440,7 @@ func parseDiffGitArgs(diffArgs string) (string, string, bool) {
 		// If the two strings could be equal, based on length, proceed.
 		if length%2 == 1 {
 			// If the name minus the a/ b/ prefixes is equal, proceed.
-			if len(first) >= 3 && length%2 == 1 && first[1] == '/' && first[1:] == second[1:] {
+			if len(first) >= 3 && first[1] == '/' && first[1:] == second[1:] {
 				return first, second, true
 			}
 			// If the names don't have the a/ and b/ prefixes and they're equal, proceed.

--- a/diff/testdata/delete_empty_file.diff
+++ b/diff/testdata/delete_empty_file.diff
@@ -1,0 +1,25 @@
+diff --git Euler 0011/README.txt~ Euler 0011/README.txt~
+deleted file mode 100644
+index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000
+diff --git Euler 0011/Euler0011.cpp Euler 0011/Euler0011.cpp
+deleted file mode 100644
+index 6490416c8cb4bbf2afbafa66251a9eab983086d1..0000000000000000000000000000000000000000
+--- Euler 0011/Euler0011.cpp	
++++ /dev/null
+@@ -1,1 +0,0 @@
+-#include <iostream>
+\ No newline at end of file
+diff --git Euler 0011/README.txt~ Euler 0011/README.txt~
+deleted file mode 100644
+index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000
+diff --git Euler 0011/README.txt Euler 0011/README.txt
+deleted file mode 100644
+index f8ea904baa27c54eb73cc02d5a555878b28672ff..0000000000000000000000000000000000000000
+--- Euler 0011/README.txt	
++++ /dev/null
+@@ -1,1 +0,0 @@
+-In the 20�20 grid below, four numbers along a diagonal line have been marked in red.
+\ No newline at end of file
+diff --git Euler 0011/README.txt~ Euler 0011/README.txt~
+deleted file mode 100644
+index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..0000000000000000000000000000000000000000


### PR DESCRIPTION
When no prefixes are present, the parsing failed before and the orig filename was empty. This fixes it. This broke rendering diffs with deleted empty files in Sourcegraph.