### PR TITLE
Use errors.Is/errors.As instead of == comparisons against errors

### DIFF
--- a/cmd/go-diff/go-diff.go
+++ b/cmd/go-diff/go-diff.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -45,7 +46,7 @@ func main() {
 		if fdiff != nil {
 			label = fmt.Sprintf("orig(%s) new(%s)", fdiff.OrigName, fdiff.NewName)
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -76,7 +76,7 @@ func (r *MultiFileDiffReader) ReadFileWithTrailingContent() (*FileDiff, string, 
 	if err != nil {
 		switch e := err.(type) {
 		case *ParseError:
-			if e.Err == ErrNoFileHeader || e.Err == ErrExtendedHeadersEOF {
+			if errors.Is(e.Err, ErrNoFileHeader) || errors.Is(e.Err, ErrExtendedHeadersEOF) {
 				// Any non-diff content preceding a valid diff is included in the
 				// extended headers of the following diff. In this way, mixed diff /
 				// non-diff content can be parsed. Trailing non-diff content is
@@ -114,7 +114,7 @@ func (r *MultiFileDiffReader) ReadFileWithTrailingContent() (*FileDiff, string, 
 	// need to perform the check here.
 	hr := fr.HunksReader()
 	line, err := r.reader.readLine()
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fd, "", err
 	}
 	line = bytes.TrimSuffix(line, []byte{'\n'})
@@ -152,7 +152,7 @@ func (r *MultiFileDiffReader) ReadAllFiles() ([]*FileDiff, error) {
 		if d != nil {
 			ds = append(ds, d)
 		}
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return ds, nil
 		}
 		if err != nil {
@@ -224,7 +224,7 @@ func (r *FileDiffReader) ReadAllHeaders() (*FileDiff, error) {
 	fd := &FileDiff{}
 
 	fd.Extended, err = r.ReadExtendedHeaders()
-	if pe, ok := err.(*ParseError); ok && pe.Err == ErrExtendedHeadersEOF {
+	if pe, ok := err.(*ParseError); ok && errors.Is(pe.Err, ErrExtendedHeadersEOF) {
 		wasEmpty := handleEmpty(fd)
 		if wasEmpty {
 			return fd, nil
@@ -305,7 +305,7 @@ func (r *FileDiffReader) readOneFileHeader(prefix []byte) (filename string, time
 	if r.fileHeaderLine == nil {
 		var err error
 		line, err = r.reader.readLine()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return "", nil, &ParseError{r.line, r.offset, ErrNoFileHeader}
 		} else if err != nil {
 			return "", nil, err
@@ -363,7 +363,7 @@ func (r *FileDiffReader) ReadExtendedHeaders() ([]string, error) {
 		if r.fileHeaderLine == nil {
 			var err error
 			line, err = r.reader.readLine()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return xheaders, &ParseError{r.line, r.offset, ErrExtendedHeadersEOF}
 			} else if err != nil {
 				return xheaders, err
@@ -660,7 +660,7 @@ func (r *HunksReader) ReadHunk() (*Hunk, error) {
 		} else {
 			line, err = r.reader.readLine()
 			if err != nil {
-				if err == io.EOF && r.hunk != nil {
+				if errors.Is(err, io.EOF) && r.hunk != nil {
 					return r.hunk, nil
 				}
 				return nil, err
@@ -825,7 +825,7 @@ func (r *HunksReader) ReadAllHunks() ([]*Hunk, error) {
 	linesRead := int32(0)
 	for {
 		hunk, err := r.ReadHunk()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return hunks, nil
 		}
 		if hunk != nil {

--- a/diff/reader_util.go
+++ b/diff/reader_util.go
@@ -84,7 +84,7 @@ func (l *lineReader) nextNextLineStartsWith(prefix string) (bool, error) {
 // false and ignore the error when readErr is io.EOF.
 func (l *lineReader) lineHasPrefix(line []byte, prefix string, readErr error) (bool, error) {
 	if readErr != nil {
-		if readErr == io.EOF || readErr == bufio.ErrBufferFull {
+		if errors.Is(readErr, io.EOF) || errors.Is(readErr, bufio.ErrBufferFull) {
 			return false, nil
 		}
 		return false, readErr
@@ -100,10 +100,10 @@ func (l *lineReader) lineHasPrefix(line []byte, prefix string, readErr error) (b
 // will return any other errors it receives from the underlying call to ReadBytes.
 func readLine(r *bufio.Reader, keepCR bool) ([]byte, error) {
 	line, err := r.ReadBytes('\n')
-	if err == io.EOF && len(line) == 0 {
+	if errors.Is(err, io.EOF) && len(line) == 0 {
 		return nil, io.EOF
 	}
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	if line[len(line)-1] == '\n' {


### PR DESCRIPTION
This change replaces direct `==`/`!=` comparisons against error values with the
standard library helpers `errors.Is` (for sentinel error values) and `errors.As`
(for error types).

Direct comparison breaks when an error is wrapped (e.g. with `fmt.Errorf("...: %w", err)`),
whereas `errors.Is`/`errors.As` traverse the wrap chain.

Notes:
- Comparisons against `nil` are intentionally left unchanged.
- Test files, vendored code, and generated code were not modified.

[_Created by Sourcegraph batch change `bahrmichael/432ac474-d2a7-4950-b17f-2a1b1fe59e87`._](https://sourcegraph.sourcegraph.com/users/bahrmichael/batch-changes/432ac474-d2a7-4950-b17f-2a1b1fe59e87)