### PR TITLE
Migrate error comparisons to errors.Is/errors.As

### DIFF
--- a/diff/parse.go
+++ b/diff/parse.go
@@ -74,9 +74,11 @@ func (r *MultiFileDiffReader) ReadFileWithTrailingContent() (*FileDiff, string, 
 
 	fd, err := fr.ReadAllHeaders()
 	if err != nil {
-		switch e := err.(type) {
-		case *ParseError:
-			if e.Err == ErrNoFileHeader || e.Err == ErrExtendedHeadersEOF {
+		var pe *ParseError
+		var oe OverflowError
+		switch {
+		case errors.As(err, &pe):
+			if errors.Is(pe.Err, ErrNoFileHeader) || errors.Is(pe.Err, ErrExtendedHeadersEOF) {
 				// Any non-diff content preceding a valid diff is included in the
 				// extended headers of the following diff. In this way, mixed diff /
 				// non-diff content can be parsed. Trailing non-diff content is
@@ -91,8 +93,8 @@ func (r *MultiFileDiffReader) ReadFileWithTrailingContent() (*FileDiff, string, 
 			}
 			return nil, "", err
 
-		case OverflowError:
-			r.nextFileFirstLine = []byte(e)
+		case errors.As(err, &oe):
+			r.nextFileFirstLine = []byte(oe)
 			return fd, "", nil
 
 		default:
@@ -124,8 +126,10 @@ func (r *MultiFileDiffReader) ReadFileWithTrailingContent() (*FileDiff, string, 
 		r.line = fr.line
 		r.offset = fr.offset
 		if err != nil {
-			if e0, ok := err.(*ParseError); ok {
-				if e, ok := e0.Err.(*ErrBadHunkLine); ok {
+			var e0 *ParseError
+			if errors.As(err, &e0) {
+				var e *ErrBadHunkLine
+				if errors.As(e0.Err, &e) {
 					// This just means we finished reading the hunks for the
 					// current file. See the ErrBadHunkLine doc for more info.
 					r.nextFileFirstLine = e.Line
@@ -224,13 +228,15 @@ func (r *FileDiffReader) ReadAllHeaders() (*FileDiff, error) {
 	fd := &FileDiff{}
 
 	fd.Extended, err = r.ReadExtendedHeaders()
-	if pe, ok := err.(*ParseError); ok && pe.Err == ErrExtendedHeadersEOF {
+	var pe *ParseError
+	var oe OverflowError
+	if errors.As(err, &pe) && errors.Is(pe.Err, ErrExtendedHeadersEOF) {
 		wasEmpty := handleEmpty(fd)
 		if wasEmpty {
 			return fd, nil
 		}
 		return fd, err
-	} else if _, ok := err.(OverflowError); ok {
+	} else if errors.As(err, &oe) {
 		handleEmpty(fd)
 		return fd, err
 	} else if err != nil {

--- a/diff/reader_util.go
+++ b/diff/reader_util.go
@@ -84,7 +84,7 @@ func (l *lineReader) nextNextLineStartsWith(prefix string) (bool, error) {
 // false and ignore the error when readErr is io.EOF.
 func (l *lineReader) lineHasPrefix(line []byte, prefix string, readErr error) (bool, error) {
 	if readErr != nil {
-		if readErr == io.EOF || readErr == bufio.ErrBufferFull {
+		if readErr == io.EOF || errors.Is(readErr, bufio.ErrBufferFull) {
 			return false, nil
 		}
 		return false, readErr


### PR DESCRIPTION
This change migrates direct error comparisons and error type assertions to the
modern `errors` package idioms:

- `err == SentinelErr` / `err != SentinelErr` -> `errors.Is(err, SentinelErr)` / `!errors.Is(...)`
  for sentinels such as `sql.ErrNoRows`, `context.Canceled`, `context.DeadlineExceeded`,
  `http.ErrServerClosed`, `io.ErrUnexpectedEOF`, `os.ErrNotExist`, etc.
- Error type assertions and `switch err.(type)` classification -> `errors.As`.

Excluded by design: `io.EOF` comparisons (idiomatic in reader loops) and `_test.go` files.

This makes error checks robust to wrapped errors (`fmt.Errorf("...: %w", err)`).

Generated by a Sourcegraph batch change.

[_Created by Sourcegraph batch change `robert/58006530-3ddc-4c11-ad42-8d8eed8bc63f`._](https://sourcegraph.sourcegraph.com/users/robert/batch-changes/58006530-3ddc-4c11-ad42-8d8eed8bc63f)