### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - "1.14.x"
+  - "1.26.4"
 script:
   - GO111MODULE=on go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"github.com/google/go-cmp/cmp"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -30,7 +30,7 @@ func init() {
 
 func TestParseHunkNoChunksize(t *testing.T) {
 	filename := "sample_no_chunksize.diff"
-	diffData, err := ioutil.ReadFile(filepath.Join("testdata", filename))
+	diffData, err := os.ReadFile(filepath.Join("testdata", filename))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestParseHunksAndPrintHunks(t *testing.T) {
 		{filename: "sample_hunk_lines_start_with_minuses_pluses.diff"},
 	}
 	for _, test := range tests {
-		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+		diffData, err := os.ReadFile(filepath.Join("testdata", test.filename))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -289,7 +289,7 @@ func TestParseFileDiffHeaders(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.filename, func(t *testing.T) {
-			diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+			diffData, err := os.ReadFile(filepath.Join("testdata", test.filename))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -835,7 +835,7 @@ func TestParseMultiFileDiffHeaders(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.filename, func(t *testing.T) {
-			diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+			diffData, err := os.ReadFile(filepath.Join("testdata", test.filename))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -874,7 +874,7 @@ func TestParseFileDiffAndPrintFileDiff(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+		diffData, err := os.ReadFile(filepath.Join("testdata", test.filename))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -922,7 +922,7 @@ func TestParseMultiFileDiffAndPrintMultiFileDiff(t *testing.T) {
 		{filename: "sample_multi_file_without_extended.diff", wantFileDiffs: 2},
 	}
 	for _, test := range tests {
-		diffData, err := ioutil.ReadFile(filepath.Join("testdata", test.filename))
+		diffData, err := os.ReadFile(filepath.Join("testdata", test.filename))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -944,7 +944,7 @@ func TestParseMultiFileDiffAndPrintMultiFileDiff(t *testing.T) {
 			t.Errorf("%s: PrintMultiFileDiff: %s", test.filename, err)
 		}
 		if test.wantOutFileName != "" {
-			diffData, err = ioutil.ReadFile(filepath.Join("testdata", test.wantOutFileName))
+			diffData, err = os.ReadFile(filepath.Join("testdata", test.wantOutFileName))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -956,11 +956,11 @@ func TestParseMultiFileDiffAndPrintMultiFileDiff(t *testing.T) {
 }
 
 func TestParseMultiFileDiffAndPrintMultiFileDiffIncludingTrailingContent(t *testing.T) {
-	testInput, err := ioutil.ReadFile(filepath.Join("testdata", "sample_multi_file_trailing_content.diff"))
+	testInput, err := os.ReadFile(filepath.Join("testdata", "sample_multi_file_trailing_content.diff"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedDiffs, err := ioutil.ReadFile(filepath.Join("testdata", "sample_multi_file_trailing_content_diffsonly.diff"))
+	expectedDiffs, err := os.ReadFile(filepath.Join("testdata", "sample_multi_file_trailing_content_diffsonly.diff"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1124,7 +1124,7 @@ func TestFileDiff_Stat(t *testing.T) {
 }
 
 func TestParseMultiFileDiff_Comprehensive(t *testing.T) {
-	diffData, err := ioutil.ReadFile(filepath.Join("testdata", "sample_multi_file.diff"))
+	diffData, err := os.ReadFile(filepath.Join("testdata", "sample_multi_file.diff"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/diff/parse.go
+++ b/diff/parse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -679,7 +680,7 @@ func (r *HunksReader) ReadHunk() (*Hunk, error) {
 
 			// Parse hunk header.
 			r.hunk = &Hunk{}
-			items := []interface{}{
+			items := []any{
 				&r.hunk.OrigStartLine, &r.hunk.OrigLines,
 				&r.hunk.NewStartLine, &r.hunk.NewLines,
 			}
@@ -772,12 +773,7 @@ var linePrefixes = []byte{' ', '-', '+', '\\'}
 
 // linePrefix returns true if 'c' is in 'linePrefixes'.
 func linePrefix(c byte) bool {
-	for _, p := range linePrefixes {
-		if p == c {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(linePrefixes, c)
 }
 
 // normalizeHeader takes a header of the form:
@@ -846,12 +842,12 @@ func parseOnlyInMessage(line []byte) (bool, []byte, []byte) {
 		return false, nil, nil
 	}
 	line = line[len(onlyInMessagePrefix):]
-	idx := bytes.Index(line, []byte(": "))
-	if idx < 0 {
+	before, after, ok := bytes.Cut(line, []byte(": "))
+	if !ok {
 		return false, nil, nil
 	}
-	filename := bytes.TrimSuffix(line[idx+2:], []byte("\r"))
-	return true, line[:idx], filename
+	filename := bytes.TrimSuffix(after, []byte("\r"))
+	return true, before, filename
 }
 
 // A ParseError is a description of a unified diff syntax error.

--- a/diff/reader_util_test.go
+++ b/diff/reader_util_test.go
@@ -77,7 +77,7 @@ index 0000000..3be2928
 
 	in := newLineReader(strings.NewReader(input))
 	out := []string{}
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		l, err := in.readLine()
 		if err != nil {
 			t.Fatal(err)

--- a/diff/reverse_test.go
+++ b/diff/reverse_test.go
@@ -159,7 +159,6 @@ func TestReverseRoundTripOnTestdata(t *testing.T) {
 	}
 
 	for _, fixture := range fixtures {
-		fixture := fixture
 		name := filepath.Base(fixture)
 
 		t.Run(name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sourcegraph/go-diff
 
-go 1.20
+go 1.26.4
 
 require github.com/google/go-cmp v0.5.2


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)