### PR TITLE
Expose sentinel error for reversing Git copies

### DIFF
--- a/diff/reverse.go
+++ b/diff/reverse.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// ErrCannotReverseCopy is returned when a Git copy diff cannot be reversed.
+var ErrCannotReverseCopy = errors.New("cannot reverse a git copy diff")
+
 // ReverseFileDiff takes a diff.FileDiff and returns the reverse operation.
 // This is a FileDiff that undoes the edit of the original. Git copy diffs
 // cannot be reversed because they do not contain enough information to delete
@@ -50,7 +53,7 @@ func reverseExtendedHeaders(headers []string) ([]string, error) {
 		case strings.HasPrefix(header, "index "):
 			reversed[i] = reverseIndexHeader(header)
 		case strings.HasPrefix(header, "copy from "), strings.HasPrefix(header, "copy to "):
-			return nil, errors.New("cannot reverse a git copy diff")
+			return nil, ErrCannotReverseCopy
 		}
 	}
 	swapHeaderValues(reversed, "old mode ", "new mode ")

--- a/diff/reverse_test.go
+++ b/diff/reverse_test.go
@@ -290,8 +290,8 @@ func TestReverseFileDiffRejectsCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ReverseFileDiff(fd); err == nil {
-		t.Fatal("ReverseFileDiff succeeded for a copy diff")
+	if _, err := ReverseFileDiff(fd); err != ErrCannotReverseCopy {
+		t.Fatalf("ReverseFileDiff error = %v, want ErrCannotReverseCopy", err)
 	}
 }
 


### PR DESCRIPTION
This is a narrow follow-up to #92. Git copy diffs are valid input but cannot be reversed because they lack enough information to delete the copied file. `ReverseFileDiff` now returns the exported `ErrCannotReverseCopy` sentinel for that case, allowing callers to distinguish it from other failures by direct equality (and therefore with `errors.Is` as well) without changing the existing error text or reversal behavior.

The focused copy-diff test now verifies the sentinel identity. Validation passed with `go test -race ./...`, `go vet ./...`, and `git diff --check`.